### PR TITLE
exclude clojure.core/update

### DIFF
--- a/src/net/cgrand/parsley/fold.clj
+++ b/src/net/cgrand/parsley/fold.clj
@@ -7,7 +7,8 @@
 ;   You must not remove this notice, or any other, from this software.
 
 (ns net.cgrand.parsley.fold
-  (:require [net.cgrand.parsley.util :as u]))
+  (:require [net.cgrand.parsley.util :as u])
+  (:refer-clojure :exclude [update]))
 
 (defprotocol EphemeralFolding
   (unexpected! [this s])


### PR DESCRIPTION
avoid warning in clojure 1.7
